### PR TITLE
stream HTML direct from SPIFFS file

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -51,8 +51,7 @@ void ConfigManager::handleAPGet() {
         return;
     }
 
-    String content = f.readString();
-    server->send(200, "text/html", content);
+    server->streamFile(f, "text/html");
 
     f.close();
 }


### PR DESCRIPTION
As discussed in issue #11 - avoids loading HTML from file into RAM before streaming to the client - faster and much more memory-efficient. Thanks for the pull request request :)