### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,8 +16,8 @@ setAPName	KEYWORD2
 setAPFilename	KEYWORD2
 setWifiConnectRetries	KEYWORD2
 setWifiConnectInterval	KEYWORD2
-setAPCallback   KEYWORD2
-setAPICallback  KEYWORD2
+setAPCallback	KEYWORD2
+setAPICallback	KEYWORD2
 addParameter	KEYWORD2
 begin	KEYWORD2
 loop	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords