### PR TITLE
Callbacks must be defined before we call `ConfigManager.begin(config)`

### DIFF
--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -33,12 +33,11 @@ void setup() {
     configManager.addParameter("hour", &config.hour);
     configManager.addParameter("password", config.password, 20, set);
     configManager.addParameter("version", &meta.version, get);
-    configManager.begin(config);
 
     configManager.setAPCallback(createCustomRoute);
     configManager.setAPICallback(createCustomRoute);
 
-    //
+    configManager.begin(config);
 }
 
 void loop() {


### PR DESCRIPTION
I found that when trying the example code the callback was never triggered as it was defined after the configuration manager was setup.

This resolves that issue.