### PR TITLE
Update README.md - clarification of CALLBACK methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ void setAPCallback(std::function<void(WebServer*)> callback)
 ```
 void setAPICallback(std::function<void(WebServer*)> callback)
 ```
-> Create a custom http endpoint when the device is running in API/Settings mode.
+> Sets a function that will be called when the WebServer is started in API/Settings mode allowing custom HTTP endpoints to be created.
 
 ### setWifiConnectRetries
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ void setAPTimeout(const int timeout)
 ```
 void setAPCallback(std::function<void(WebServer*)> callback)
 ```
-> Create a custom http endpoint when the device is running in AP mode.
+> Sets a function that will be called when the WebServer is started in AP mode allowing custom HTTP endpoints to be created.
 
 ### setAPICallback
 ```

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ void setAPTimeout(const int timeout)
 ```
 void setAPCallback(std::function<void(WebServer*)> callback)
 ```
-> Sets a callback allowing customized http endpoints to be set when the access point is setup.
+> Create a custom http endpoint when the device is running in AP mode.
 
 ### setAPICallback
 ```
 void setAPICallback(std::function<void(WebServer*)> callback)
 ```
-> Sets a callback allowing customized http endpoints to be set when the api is setup.
+> Create a custom http endpoint when the device is running in API/Settings mode.
 
 ### setWifiConnectRetries
 ```


### PR DESCRIPTION
Documentation on the two callback set up methods was vague. I struggled to figure out what it was doing (they aren't actually callbacks from what I gather, where it gets called after something else). Appears to be custom endpoints that are only available during the specific running mode (AP or API Settings)