### PR TITLE
Adds extensible file stream function that can be used for the endpoint callback hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ void loop()
 ```
 > Handles any waiting REST requests.
 
+### streamFile(const char &ast;file, const char mime[])
+
+```
+server->on("/settings.html", HTTPMethod::HTTP_GET, [server](){
+    configManager.streamFile(settingsHTML, mimeHTML);
+});
+```
+
+> Stream a file to the server when using custom routing endpoints. See `example/save_config_demo.ino`
+
+
 # Endpoints
 
 ### GET /

--- a/examples/save_config_demo/save_config_demo.ino
+++ b/examples/save_config_demo/save_config_demo.ino
@@ -1,6 +1,5 @@
 #include "ConfigManager.h"
 
-const char mimeHTML[] PROGMEM = "text/html";
 const char *configHTMLFile = "/settings.html";
 
 struct Config {
@@ -22,18 +21,7 @@ ConfigManager configManager;
 
 void createCustomRoute(WebServer *server) {
   server->on("/settings.html", HTTPMethod::HTTP_GET, [server](){
-    SPIFFS.begin();
-
-    File f = SPIFFS.open(configHTMLFile, "r");
-    if (!f) {
-      Serial.println(F("file open failed"));
-      server->send(404, FPSTR(mimeHTML), F("File not found"));
-      return;
-    }
-
-    server->streamFile(f, FPSTR(mimeHTML));
-
-    f.close();
+    configManager.streamFile(settingsHTML, mimeHTML);
   });
 }
 

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -30,8 +30,13 @@ extern bool DEBUG_MODE;
 #define DebugPrintln(a) (DEBUG_MODE ? Serial.println(a) : false)
 #define DebugPrint(a) (DEBUG_MODE ? Serial.print(a) : false)
 
-enum Mode {ap, api};
+extern const char mimeHTML[];
+extern const char mimeJSON[];
+extern const char mimePlain[];
+extern const char mimeCSS[];
+extern const char mimeJS[];
 
+enum Mode {ap, api};
 enum ParameterMode { get, set, both};
 
 /**
@@ -135,6 +140,8 @@ public:
     void setAPCallback(std::function<void(WebServer*)> callback);
     void setAPICallback(std::function<void(WebServer*)> callback);
     void loop();
+    void streamFile(const char *file, const char mime[]);
+    void handleNotFound();
 
     template<typename T>
     void begin(T &config) {
@@ -189,7 +196,6 @@ private:
     void handleAPPost();
     void handleRESTGet();
     void handleRESTPut();
-    void handleNotFound();
 
     bool wifiConnected();
     void setup();


### PR DESCRIPTION
Create the ConfigManager method `streamFile` which can be used to abstract the streaming of files for serving new endpoints 

From `save_config_demo.ino`
```
void createCustomRoute(WebServer *server) {
  server->on("/settings.html", HTTPMethod::HTTP_GET, [server](){
    configManager.streamFile(settingsHTML, mimeHTML);
  });
}
```