### PR TITLE
Add /scan route and scanning ability | slight routing initialize cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,18 @@ server->on("/settings.html", HTTPMethod::HTTP_GET, [server](){
 
 # Endpoints
 
-### GET /
+
+## GET /
+
+###### *(AP,API)*
 
 > Gets the HTML page that is used to set the Wifi SSID and password.
 
 + Response 200 *(text/html)*
 
-### POST /
+## POST /
+
+###### *(AP,API)*
 
 > Sets the Wifi SSID and password. The form example can be found in the ```data``` directory.
 
@@ -225,7 +230,25 @@ ssid=access point&password=some password
 }
 ```
 
-### GET /settings
+## GET /scan
+
+###### *(AP,API)*
+
+> Scans visible networks
+
++ Response 200 *(application/json)*
+
+```json
+{
+  "ssid": "access point name",
+  "strength": *int*, 
+  "security": "none" *or* "enabled"
+}
+```
+
+## GET /settings
+
+###### *(API)*
 
 > Gets the settings set in ```addParameter```.
 
@@ -238,7 +261,9 @@ ssid=access point&password=some password
 }
 ```
 
-### PUT /settings
+## PUT /settings
+
+###### *(API)*
 
 > Sets the settings set in ```addParameter```.
 

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -136,6 +136,46 @@ void ConfigManager::handleAPPost() {
     ESP.restart();
 }
 
+void ConfigManager::handleScanGet() {
+    DynamicJsonBuffer jsonBuffer;
+    JsonArray& jsonArray = jsonBuffer.createArray();
+
+    DebugPrintln("scanning WIFI networks...");
+    int n = WiFi.scanNetworks();
+    DebugPrintln("scan complete");
+    if (n == 0) {
+        DebugPrintln("no networks found");
+    } else {
+        DebugPrint(n);
+        DebugPrintln(" networks found:");
+
+        for (int i = 0; i < n; ++i) {
+            String ssid = WiFi.SSID(i);
+            int rssi = WiFi.RSSI(i);
+            String security = WiFi.encryptionType(i) == ENC_TYPE_NONE ? "none" : "enabled";
+
+            DebugPrint("Name: ");
+            DebugPrint(ssid);
+            DebugPrint(" - Strength: ");
+            DebugPrint(rssi);
+            DebugPrint(" - Security: ");
+            DebugPrintln(security);
+
+            DynamicJsonBuffer jsonBufferItem;
+            JsonObject& obj = jsonBuffer.createObject();
+            obj.set("ssid", ssid);
+            obj.set("strength", rssi);
+            obj.set("security", security == "none" ? false : true);
+            jsonArray.add(obj);
+        }
+    }
+
+    String body;
+    jsonArray.printTo(body);
+
+    server->send(200, FPSTR(mimeJSON), body);
+}
+
 void ConfigManager::handleRESTGet() {
     DynamicJsonBuffer jsonBuffer;
     JsonObject& obj = jsonBuffer.createObject();
@@ -243,9 +283,6 @@ void ConfigManager::setup() {
 }
 
 void ConfigManager::startAP() {
-    const char* headerKeys[] = {"Content-Type"};
-    size_t headerKeysSize = sizeof(headerKeys)/sizeof(char*);
-
     mode = ap;
 
     DebugPrintln(F("Starting Access Point"));
@@ -267,11 +304,7 @@ void ConfigManager::startAP() {
     dnsServer->setErrorReplyCode(DNSReplyCode::NoError);
     dnsServer->start(DNS_PORT, "*", ip);
 
-    server.reset(new WebServer(80));
-    server->collectHeaders(headerKeys, headerKeysSize);
-    server->on("/", HTTPMethod::HTTP_GET, std::bind(&ConfigManager::handleAPGet, this));
-    server->on("/", HTTPMethod::HTTP_POST, std::bind(&ConfigManager::handleAPPost, this));
-    server->onNotFound(std::bind(&ConfigManager::handleNotFound, this));
+    createBaseWebServer();
 
     if (apCallback) {
         apCallback(server.get());
@@ -283,24 +316,30 @@ void ConfigManager::startAP() {
 }
 
 void ConfigManager::startApi() {
-    const char* headerKeys[] = {"Content-Type"};
-    size_t headerKeysSize = sizeof(headerKeys)/sizeof(char*);
-
     mode = api;
 
-    server.reset(new WebServer(80));
-    server->collectHeaders(headerKeys, headerKeysSize);
-    server->on("/", HTTPMethod::HTTP_GET, std::bind(&ConfigManager::handleAPGet, this));
-    server->on("/", HTTPMethod::HTTP_POST, std::bind(&ConfigManager::handleAPPost, this));
+    createBaseWebServer();
     server->on("/settings", HTTPMethod::HTTP_GET, std::bind(&ConfigManager::handleRESTGet, this));
     server->on("/settings", HTTPMethod::HTTP_PUT, std::bind(&ConfigManager::handleRESTPut, this));
-    server->onNotFound(std::bind(&ConfigManager::handleNotFound, this));
 
     if (apiCallback) {
         apiCallback(server.get());
     }
 
     server->begin();
+}
+
+void ConfigManager::createBaseWebServer() {
+    const char* headerKeys[] = {"Content-Type"};
+    size_t headerKeysSize = sizeof(headerKeys)/sizeof(char*);
+
+    server.reset(new WebServer(80));
+    server->collectHeaders(headerKeys, headerKeysSize);
+
+    server->on("/", HTTPMethod::HTTP_GET, std::bind(&ConfigManager::handleAPGet, this));
+    server->on("/", HTTPMethod::HTTP_POST, std::bind(&ConfigManager::handleAPPost, this));
+    server->on("/scan", HTTPMethod::HTTP_GET, std::bind(&ConfigManager::handleScanGet, this));
+    server->onNotFound(std::bind(&ConfigManager::handleNotFound, this));
 }
 
 void ConfigManager::readConfig() {

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -194,6 +194,7 @@ private:
 
     void handleAPGet();
     void handleAPPost();
+    void handleScanGet();
     void handleRESTGet();
     void handleRESTPut();
 
@@ -201,6 +202,7 @@ private:
     void setup();
     void startAP();
     void startApi();
+    void createBaseWebServer();
 
     void readConfig();
     void writeConfig();


### PR DESCRIPTION
Add /scan route and scanning ability 

Cleans the shared routing endpoint setup calls via private `baseRoutingSetup()`