### PR TITLE
move mode starting methods public; change magic check logic

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -32,20 +32,22 @@ void ConfigManager::setup() {
     DebugPrint(ssid);
     DebugPrintln(F("\""));
 
-    EEPROM.get(MAGIC_LENGTH + SSID_LENGTH, password);
     readConfig();
 
-    WiFi.begin(ssid, password[0] == '\0' ? NULL : password);
+    if (strlen(ssid) > 0) {
+      EEPROM.get(MAGIC_LENGTH + SSID_LENGTH, password);
+      WiFi.begin(ssid, password[0] == '\0' ? NULL : password);
 
-    if (wifiConnected()) {
-      DebugPrint(F("Connected to "));
-      DebugPrint(ssid);
-      DebugPrint(F(" with "));
-      DebugPrintln(WiFi.localIP());
+      if (wifiConnected()) {
+        DebugPrint(F("Connected to "));
+        DebugPrint(ssid);
+        DebugPrint(F(" with "));
+        DebugPrintln(WiFi.localIP());
 
-      WiFi.mode(WIFI_STA);
+        WiFi.mode(WIFI_STA);
 
-      startApi();
+        startApi();
+      }
     }
   } else {
     // We are at a cold start, don't bother timing out.
@@ -235,7 +237,7 @@ void ConfigManager::clearWifiSettings(bool reboot) {
   memset(password, 0, PASSWORD_LENGTH);
 
   DebugPrintln(F("Clearing WiFi connection."));
-  storeWifiSettings(ssid, password, true);
+  storeWifiSettings(ssid, password, false);
 
   if (reboot) {
     ESP.restart();

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -175,6 +175,9 @@ class ConfigManager {
   void startWebserver();
   void stopWebserver();
   void save();
+  void startAP();
+  void startAPApi();
+  void startApi();
 
   template <typename T>
   void begin(T& config) {
@@ -239,9 +242,6 @@ class ConfigManager {
 
   bool wifiConnected();
   void setup();
-  void startAP();
-  void startAPApi();
-  void startApi();
   void createBaseWebServer();
 
   void readConfig();


### PR DESCRIPTION
# Objective

To move the following methods out of the ConfigManager private space. This will allow the main project to selectively start these services out of band. 

```
void startAP();
void startAPApi();
void startApi();
```

# Use case

I needed the project to turn from STATION mode to AP mode 

