### PR TITLE
Whoops -- fix reset of memory

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -313,10 +313,13 @@ JsonObject ConfigManager::decodeJson(String jsonString) {
 }
 
 void ConfigManager::clearAllSettings(bool reboot) {
+  this->clearSettings(false);
+  this->clearWifiSettings(false);
   EEPROM.put(0, magicBytesEmpty);
   EEPROM.commit();
-  this->clearSettings(false);
-  this->clearWifiSettings(reboot);
+  if (reboot) {
+    ESP.restart();
+  }
 }
 
 void ConfigManager::readConfig() {


### PR DESCRIPTION
# Bug

the last minute add of `commitChanges` made all saves to the memory set magicByte, this just makes sure that the clearing resets the memory to MagicEmpty