### PR TITLE
check for leading slash on files

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -400,7 +400,7 @@ void ConfigManager::startWebserver() {
 
 void ConfigManager::stopWebserver() {
   this->server->stop();
-  DebugPrintln(F("Webserver Stopped"));
+  DebugPrintln(F("ConfigManager Webserver Stopped"));
   this->webserverRunning = false;
 }
 
@@ -434,16 +434,27 @@ void ConfigManager::createBaseWebServer() {
 void ConfigManager::streamFile(const char* file, const char mime[]) {
   SPIFFS.begin();
 
-  File f = SPIFFS.open(file, "r");
-  if (!f) {
+  File f;
+
+  if (file[0] == '/') {
+    f = SPIFFS.open(file, "r");
+  } else {
+    size_t len = strlen(file);
+    char filepath[len+1];
+    strcpy(filepath, "/");
+    strcat(filepath, file);
+    f = SPIFFS.open(filepath, "r");
+  }
+
+  if (f) {
+    server->streamFile(f, FPSTR(mime));
+    f.close();
+  } else {
     DebugPrint(F("file open failed "));
     DebugPrintln(file);
     handleNotFound();
-    return;
   }
 
-  server->streamFile(f, FPSTR(mime));
-  f.close();
 }
 
 void ConfigManager::handleAPGet() {


### PR DESCRIPTION
# Objective

SPIFFS requires a leading `/` on files, debugging this when you leave it off is PAINFUL. This attempts to add the leading slash. Im 100% sure there is probably a better way to do the string manipulation, but I never found the magic incantation 

- `char*` gymnastics is painful

# Alternative

Instead of adding the leading `/` could at least write an error to the fact that there should be one, to make the next persons life easier. 

# Open to feedback on the choice! 