### PR TITLE
Request: Add small delay before restart to allow sending response

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -507,6 +507,7 @@ void ConfigManager::handleAPPost() {
   storeWifiSettings(ssid, password);
 
   server->send(204, FPSTR(mimePlain), F("Saved. Will attempt to reboot."));
+  delay(500); // Allow enough time for the response to be sent before restarting.
 
   ESP.restart();
 }


### PR DESCRIPTION
I noticed when using the `/` POST endpoint for setting the ssid and password that the device will restart before the browser gets a response back from the server. By adding a small delay before restarting, there is enough time for the web server to finish processing the request. 