### PR TITLE
re-order softAP setup

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -120,13 +120,15 @@ void ConfigManager::startAP() {
   DebugPrintln(F("Starting Access Point"));
 
   WiFi.mode(WIFI_AP);
-  WiFi.softAP(apName, apPassword);
-
-  delay(500);  // Need to wait to get IP
 
   IPAddress ip(192, 168, 1, 1);
   IPAddress NMask(255, 255, 255, 0);
   WiFi.softAPConfig(ip, ip, NMask);
+
+  // Need to wait to get IP
+  delay(500);
+
+  WiFi.softAP(apName, apPassword);
 
   DebugPrint("AP Name: ");
   DebugPrintln(apName);

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -125,7 +125,7 @@ void ConfigManager::startAP() {
   IPAddress NMask(255, 255, 255, 0);
   WiFi.softAPConfig(ip, ip, NMask);
 
-  // Need to wait to get IP
+  // Need to wait on config
   delay(500);
 
   WiFi.softAP(apName, apPassword);


### PR DESCRIPTION
I swear, saying HI yesterday was not to get this MR in ;) 

Im not 100% positive this is correct, but it fixes.
Prior to this change, every time I would connect to the AP to do the configure, I would get and IP of `169.254.128.129`
Some painful googling, it looks like this is something that has creeped into the underlying ESP codebase.

https://github.com/espressif/esp-idf/issues/6108

I finally found this reference, and doing this swap was the only thing that would allow the client to get a proper IP repeatably 

https://github.com/esp8266/Arduino/issues/8326
