### PR TITLE
Migrated to LittleFS - andyb2000

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ configManager.save();
 
 ### Additional files saved
 
-Upload the ```index.html``` file found in the ```data``` directory into the SPIFFS.
+Upload the ```index.html``` file found in the ```data``` directory into the LittleFS (note SPIFFS is currently deprecated).
+Please see: https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html
+
 Instructions on how to do this vary based on your IDE. Below are links instructions
 on the most common IDEs:
 
@@ -96,13 +98,13 @@ on the most common IDEs:
 
 * [Arduino IDE](http://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#uploading-files-to-file-system)
 
-* [Platform IO](http://docs.platformio.org/en/stable/platforms/espressif.html#uploading-files-to-file-system-spiffs)
+* [Platform IO](http://docs.platformio.org/en/stable/platforms/espressif.html#uploading-files-to-file-system)
 
 #### ESP32
 
 * [Arduino IDE](https://github.com/me-no-dev/arduino-esp32fs-plugin)
 
-* [Platform IO](http://docs.platformio.org/en/stable/platforms/espressif32.html#uploading-files-to-file-system-spiffs)
+* [Platform IO](http://docs.platformio.org/en/stable/platforms/espressif32.html#uploading-files-to-file-system)
 
 # Documentation
 
@@ -146,7 +148,7 @@ void setAPPassword(const char *password)
 ```
 void setAPFilename(const char *filename)
 ```
-> Sets the path in SPIFFS to the webpage to be served by the access point.
+> Sets the path in LittleFS to the webpage to be served by the access point.
 
 ### setAPTimeout
 ```

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ConfigManager",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": "wifi, wi-fi, config",
   "description": "WiFi connection manager for ESP8266 and ESP32",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ConfigManager
-version=2.1.1
+version=2.1.2
 author=Nick Wiersma <nick@wiersma.co.za>
 maintainer=Nick Wiersma <nick@wiersma.co.za>
 sentence=WiFi connection manager for ESP8266 and ESP32

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -454,18 +454,18 @@ void ConfigManager::createBaseWebServer() {
 }
 
 void ConfigManager::streamFile(const char* file, const char mime[]) {
-  SPIFFS.begin();
+  LittleFS.begin();
 
   File f;
 
   if (file[0] == '/') {
-    f = SPIFFS.open(file, "r");
+    f = LittleFS.open(file, "r");
   } else {
     size_t len = strlen(file);
     char filepath[len + 1];
     strcpy(filepath, "/");
     strcat(filepath, file);
-    f = SPIFFS.open(filepath, "r");
+    f = LittleFS.open(filepath, "r");
   }
 
   if (f) {

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -4,12 +4,12 @@
 #include <DNSServer.h>
 #include <EEPROM.h>
 #include <FS.h>
+#include <LittleFS.h>
 
 #if defined(ARDUINO_ARCH_ESP8266)  // ESP8266
 #include <ESP8266WebServer.h>
 #include <ESP8266WiFi.h>
 #elif defined(ARDUINO_ARCH_ESP32)  // ESP32
-#include <SPIFFS.h>
 #include <WebServer.h>
 #include <WiFi.h>
 #endif


### PR DESCRIPTION
Simple change to move to use LittleFS due to SPIFFS being currently deprecated.
(See https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-deprecation-warning)
