### PR TITLE
update to use array index operator notation

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -492,8 +492,8 @@ void ConfigManager::handleAPPost() {
   if (isJson) {
     JsonObject obj = decodeJson(server->arg("plain"));
 
-    ssid = obj.getMember("ssid").as<String>();
-    password = obj.getMember("password").as<String>();
+    ssid = String((const char*)obj["ssid"]);
+    password = String((const char*)obj["password"]);
   } else {
     ssid = server->arg("ssid");
     password = server->arg("password");

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -75,15 +75,13 @@ class ConfigParameter : public BaseParameter {
   void update(T value) { *ptr = value; }
 
   void fromJson(JsonObject* json) {
-    if (json->containsKey(name) && json->getMember(name).is<T>()) {
-      this->update(json->getMember(name).as<T>());
+    const T value = (*json)[name];
+    if (value) {
+      this->update(value);
     }
   }
 
-  void toJson(JsonObject* json) {
-    // json->set(name, *ptr);
-    json->getOrAddMember(name).set(*ptr);
-  }
+  void toJson(JsonObject* json) { (*json)[name] = *ptr; }
 
   void clearData() {
     DebugPrint("Clearing: ");
@@ -121,15 +119,13 @@ class ConfigStringParameter : public BaseParameter {
   }
 
   void fromJson(JsonObject* json) {
-    if (json->containsKey(name) && json->getMember(name).is<const char*>()) {
-      const char* value = json->getMember(name).as<const char*>();
+    const char* value = (*json)[name];
+    if (value) {
       this->update(value);
     }
   }
 
-  void toJson(JsonObject* json) {
-    json->getOrAddMember(name).set((const char*)ptr);
-  }
+  void toJson(JsonObject* json) { (*json)[name] = (const char*)ptr; }
 
   void clearData() {
     DebugPrint("Clearing: ");


### PR DESCRIPTION
Addresses #122 by using the index operator notation as recommended in the [ArduinoJson docs](https://arduinojson.org/v6/api/jsonobject/containskey/#avoid).